### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/b4393b34-1522-4f56-927d-b36c987a368a/d61cbe7b-24e1-4406-a030-03c987d7705b/_apis/work/boardbadge/aa6e0a8c-29f7-422a-b669-1da941ed9880)](https://dev.azure.com/aiw-devops/b4393b34-1522-4f56-927d-b36c987a368a/_boards/board/t/d61cbe7b-24e1-4406-a030-03c987d7705b/Microsoft.RequirementCategory)
 # Contoso Traders
 
 ![Logo](./docs/images/logo-1280x640.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2515](https://dev.azure.com/aiw-devops/b4393b34-1522-4f56-927d-b36c987a368a/_workitems/edit/2515). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.